### PR TITLE
Make generateHelpMessage protected

### DIFF
--- a/fields/field.image_upload.php
+++ b/fields/field.image_upload.php
@@ -408,7 +408,7 @@
 			}
 		}
 
-		private function generateHelpMessage(){
+		protected function generateHelpMessage(){
 			$sizeMessage               = '';
 			$sizes                     = array();
 			if ($this->get( 'min_width' ) == $this->get( 'max_width' ) && $this->get( 'min_height' ) == $this->get( 'max_height' )) {


### PR DESCRIPTION
This way, other extensions like multilingual_image_upload will
be able to generate the same help message, without copying code.
