### PR TITLE
Cleanup unused erronous code for php 7.2

### DIFF
--- a/extension.driver.php
+++ b/extension.driver.php
@@ -2,9 +2,6 @@
 
 	if (!defined('__IN_SYMPHONY__')) die('<h2>Symphony Error</h2><p>You cannot directly access this file</p>');
 
-	define_safe(IMAGE_UPLOAD_NAME, 'Image Upload');
-	define_safe(IMAGE_UPLOAD_GROUP, 'image_upload');
-
 	class extension_image_upload extends Extension
 	{
 		/*------------------------------------------------------------------------------------------------*/


### PR DESCRIPTION
These 2 constant were not used anywhere. Also, with php 7.2, they give an error. The constants IMAGE_UPLOAD_NAME and IMAGE_UPLOAD_GROUP does not exists.